### PR TITLE
chore: add repository security policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # LogLens
 
-[![CI](https://img.shields.io/badge/CI-GitHub_Actions-blue)](./.github/workflows/ci.yml)
-[![CodeQL](https://img.shields.io/badge/CodeQL-code_scanning-blue)](./.github/workflows/codeql.yml)
+[![CI](https://github.com/stacknil/LogLens/actions/workflows/ci.yml/badge.svg)](https://github.com/stacknil/LogLens/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/stacknil/LogLens/actions/workflows/codeql.yml/badge.svg)](https://github.com/stacknil/LogLens/actions/workflows/codeql.yml)
 
-LogLens is a C++20 defensive log analysis CLI for Linux authentication logs.
+C++20 defensive log analysis CLI for Linux authentication logs, with parser coverage telemetry, configurable detection rules, CI, and CodeQL.
 
 It parses `auth.log` / `secure`-style syslog input and `journalctl --output=short-full`-style input, normalizes authentication evidence, applies configurable rule-based detections, and emits deterministic Markdown and JSON reports.
 
@@ -28,8 +28,6 @@ It does not provide exploitation, persistence, credential attack automation, or 
 ---
 
 LogLens is a defensive C++20 CLI that parses Linux authentication logs and produces concise Markdown and JSON reports for suspicious authentication activity. The project is intended for portfolio-grade detection engineering work, not offensive security or attack automation.
-
-These badges are local workflow markers in this working copy because the repository does not currently have a configured GitHub remote. After publishing the repository, replace them with repository-specific GitHub status badge URLs.
 
 ## Repository Checks
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Supported Versions
+
+LogLens is a small public repository under active development.
+
+| Version | Supported |
+| ------- | --------- |
+| main    | Yes       |
+| older commits / snapshots | No |
+
+At this stage, security fixes are applied to the `main` branch only.
+Historical commits, experimental branches, and stale forks should be treated as unsupported.
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue for undisclosed security vulnerabilities.
+
+Use GitHub's **private vulnerability reporting** feature for this repository if it is enabled.
+If private reporting is unavailable for any reason, contact the maintainer through a private channel listed in the repository profile or repository documentation.
+
+When reporting, please include:
+
+- a clear description of the issue
+- affected files, workflows, or code paths
+- reproduction steps or a minimal proof of concept
+- impact assessment
+- any suggested remediation, if available
+
+## Scope
+
+This repository is a defensive log-analysis CLI for Linux authentication logs.
+
+Relevant security reports may include, for example:
+
+- unsafe workflow behavior
+- supply-chain risks in CI or repository automation
+- unsafe parsing behavior that could cause security-relevant misreporting
+- vulnerabilities in repository-integrated tooling or update automation
+
+Out of scope for vulnerability reports:
+
+- feature requests
+- parser support for additional benign log variants
+- general false positives / false negatives that do not create a security vulnerability
+- issues in third-party software outside this repository unless they directly affect this repository's shipped code or workflows
+
+## Disclosure Expectations
+
+Please allow time for triage and remediation before any public disclosure.
+
+The maintainer will try to:
+
+- acknowledge receipt of a report within a reasonable timeframe
+- assess severity and impact
+- coordinate remediation privately when appropriate
+- disclose fixes responsibly after mitigation is available
+
+## Notes
+
+This repository is intended for defensive engineering and public-safe research.
+Reports that seek offensive use beyond the repository's stated scope may be declined.

--- a/docs/repo-hardening.md
+++ b/docs/repo-hardening.md
@@ -30,3 +30,10 @@ When updating a pinned action:
 2. replace the full SHA in the workflow
 3. keep the inline version comment in sync
 4. verify CI and CodeQL still run cleanly
+
+## Security Workflow
+
+- CI and CodeQL gate merges into `main`
+- GitHub Actions are pinned by full SHA
+- Updates for workflow dependencies are managed with Dependabot
+- Vulnerabilities should be reported through private vulnerability reporting


### PR DESCRIPTION
## Summary
- add SECURITY.md for private vulnerability reporting guidance
- add Dependabot updates for GitHub Actions
- document the repository security workflow and live badges

## Validation
- CI (ubuntu-latest)
- CI (windows-latest)
- CodeQL