### PR TITLE
docs: prepare v0.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@ All notable user-visible changes should be recorded here.
 
 - None yet.
 
+## v0.2.0
+
+### Added
+
+- Added dedicated sanitized parser fixture matrices for both `syslog_legacy` and `journalctl_short_full`, expanding `sshd` and `pam_unix` coverage.
+- Added deterministic unknown-line telemetry coverage for unsupported parser inputs and unknown-pattern buckets.
+
+### Changed
+
+- Moved sudo handling onto the signal layer so detectors consume one unified normalized input model.
+- Kept detector thresholds and the existing report schema stable while simplifying internal detector semantics.
+
+### Fixed
+
+- None.
+
+### Docs
+
+- Improved release-facing documentation in `README.md`, added `docs/release-process.md`, and formalized changelog discipline for future releases.
+
 ## v0.1.0
 
 ### Added


### PR DESCRIPTION
## Summary
- roll the current changelog state into a dedicated `v0.2.0` section
- keep an empty `Unreleased` section at the top for the next release cycle
- capture the user-visible parser, sudo-signal, and release-documentation changes already merged to `main`

## Scope
- docs-only change in `CHANGELOG.md`
- no source code, tests, or release assets changed

## Verification
- confirmed the branch diff only touches `CHANGELOG.md`
- local CMake/ctest were not rerun because `cmake` is not available in the current shell environment
- merge validation will rely on the repository's GitHub Actions checks
