### PR TITLE
[codex] docs: prep v0.3.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,7 @@ All notable user-visible changes should be recorded here.
 
 ### Added
 
-- Added sanitized golden `report.md` / `report.json` regression fixtures to lock report contracts.
-- Expanded parser coverage for `Accepted publickey` and selected `pam_faillock` / `pam_sss` variants.
-- Added compact host-level summaries for multi-host reports.
-- Added optional CSV export for findings and warnings when explicitly requested.
+- None yet.
 
 ### Changed
 
@@ -22,6 +19,27 @@ All notable user-visible changes should be recorded here.
 ### Docs
 
 - None yet.
+
+## v0.3.0
+
+### Added
+
+- Broadened parser support for common Linux auth families by adding `Accepted publickey` handling plus selected `pam_faillock` and `pam_sss` auth failure variants.
+- Added compact host-level summaries to `report.md` and `report.json` for multi-host inputs.
+- Added optional CSV export for findings and warnings behind an explicit `--csv` flag.
+- Added sanitized golden report-contract fixtures to lock deterministic Markdown, JSON, and CSV outputs.
+
+### Changed
+
+- Strengthened sanitized regression coverage with expanded parser fixture corpora and golden report-contract checks.
+
+### Fixed
+
+- Non-CSV runs now preserve pre-existing `findings.csv` and `warnings.csv` files instead of deleting them by default.
+
+### Docs
+
+- Synced release-facing documentation in `README.md` and added `docs/release-v0.3.0.md` for GitHub Release copy.
 
 ## v0.2.0
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ LogLens includes two minimal GitHub Actions workflows:
 - `CI` builds and tests the project on `ubuntu-latest` and `windows-latest`
 - `CodeQL` runs GitHub code scanning for C/C++ on pushes, pull requests, and a weekly schedule
 
-Both workflows are intended to stay stable enough to require on pull requests to `main`. Release-facing documentation is split across [`CHANGELOG.md`](./CHANGELOG.md), [`docs/release-process.md`](./docs/release-process.md), [`docs/release-v0.1.0.md`](./docs/release-v0.1.0.md), and the repository's GitHub release notes. The repository hardening note is in [`docs/repo-hardening.md`](./docs/repo-hardening.md), and vulnerability reporting guidance is in [`SECURITY.md`](./SECURITY.md).
+Both workflows are intended to stay stable enough to require on pull requests to `main`. Regression coverage is backed by sanitized parser fixture matrices plus golden report-contract fixtures for `report.md`, `report.json`, and optional CSV outputs. Release-facing documentation is split across [`CHANGELOG.md`](./CHANGELOG.md), [`docs/release-process.md`](./docs/release-process.md), [`docs/release-v0.1.0.md`](./docs/release-v0.1.0.md), [`docs/release-v0.3.0.md`](./docs/release-v0.3.0.md), and the repository's GitHub release notes. The repository hardening note is in [`docs/repo-hardening.md`](./docs/repo-hardening.md), and vulnerability reporting guidance is in [`SECURITY.md`](./SECURITY.md).
 
 ## Threat Model
 
@@ -58,7 +58,7 @@ LogLens currently detects:
 - One IP trying multiple usernames within 15 minutes
 - Bursty sudo activity from the same user within 5 minutes
 
-LogLens currently parses and reports these additional auth patterns beyond the core detector inputs:
+LogLens currently parses and reports these additional auth patterns beyond the core detector inputs, broadening coverage across common Linux auth families:
 
 - `Accepted publickey` SSH successes
 - `Failed publickey` SSH failures, which count toward SSH brute-force detection by default
@@ -121,7 +121,7 @@ The CSV schema is intentionally small and stable:
 - `findings.csv`: `rule`, `subject_kind`, `subject`, `event_count`, `window_start`, `window_end`, `usernames`, `summary`
 - `warnings.csv`: `kind`, `message`
 
-When an input spans multiple hostnames, both reports add compact host-level summaries without changing detector thresholds or introducing cross-host correlation logic.
+When an input spans multiple hostnames, both reports add compact host-level summaries without changing detector thresholds or introducing cross-host correlation logic. In `report.md` this appears as a host summary table, and in `report.json` it appears as a `host_summaries` array.
 
 ## Sample Output
 

--- a/docs/release-v0.3.0.md
+++ b/docs/release-v0.3.0.md
@@ -1,0 +1,21 @@
+# LogLens v0.3.0
+
+LogLens v0.3.0 expands parser family coverage, strengthens deterministic regression coverage, and improves multi-host reporting while keeping the tool intentionally defensive and public-safe.
+
+## Highlights
+
+- broadened parser support for common Linux auth families
+- strengthened sanitized corpus and golden regression coverage
+- added multi-host host summaries in `report.md` and `report.json`
+- added optional CSV export for findings and warnings
+
+## Notable changes
+
+- added parser support for `Accepted publickey` SSH successes plus selected `pam_faillock(...:auth)` and `pam_sss(...:auth)` failure variants
+- expanded sanitized parser fixture matrices and added golden report-contract fixtures for Markdown, JSON, and CSV outputs
+- added compact per-host summaries when one input file contains multiple hostnames, without introducing cross-host correlation or changing detector thresholds
+- added explicit `--csv` output for `findings.csv` and `warnings.csv`, and kept non-CSV runs non-destructive toward existing CSV files
+
+## Scope note
+
+This release broadens the parser surface and improves report ergonomics, but LogLens remains a focused offline auth-log triage CLI rather than a SIEM, enrichment pipeline, or cross-host correlation platform.


### PR DESCRIPTION
This PR prepares the release-facing documentation for `v0.3.0` without changing runtime behavior.

The user-visible surface of the repository had moved ahead of the existing release docs in three places: the README needed to reflect the broader parser family coverage, the new multi-host host summaries, and the explicit optional CSV export behavior; the changelog still held the current release scope under `Unreleased`; and there was no dedicated `v0.3.0` release-notes draft to paste into GitHub Releases.

This update keeps the diff intentionally narrow. It refreshes `README.md` so external readers can see the current parser surface, the strengthened sanitized regression story, the shape of host summaries in `report.md` and `report.json`, and the explicit non-destructive CSV behavior. It then closes out the current `Unreleased` entries into a `v0.3.0` section in `CHANGELOG.md`, including the non-destructive CSV follow-up fix. Finally, it adds `docs/release-v0.3.0.md` as a short release-notes draft aligned with the intended GitHub Release title and highlights.

Validation is documentation-only in this branch; no local build or test commands were run. GitHub CI and CodeQL will run on the PR as the merge gate.
