### PR TITLE
[codex] docs: prep v0.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@ All notable user-visible changes should be recorded here.
 
 - None yet.
 
+## v0.4.0
+
+### Added
+
+- Added optional CSV export for `findings.csv` and `warnings.csv`.
+- Added single-host and multi-host CSV regression coverage.
+- Added `.gitattributes` guardrails to reduce future line-ending drift.
+
+### Changed
+
+- None.
+
+### Fixed
+
+- Preserved default Markdown and JSON behavior when `--csv` is not requested.
+
+### Docs
+
+- None.
+
 ## v0.3.0
 
 ### Added


### PR DESCRIPTION
This PR is a minimal `v0.4.0` release-prep closure that only updates `CHANGELOG.md`.

It keeps `Unreleased` open for future work and adds a `v0.4.0` section using the intended release-facing summary for this cut: optional CSV export, preserved default Markdown/JSON behavior when `--csv` is omitted, CSV regression coverage for single-host and multi-host outputs, and `.gitattributes` guardrails for line-ending stability.

No runtime code was changed in this branch. I did not run local build or test commands because the diff is documentation-only; GitHub CI and CodeQL remain the merge gate.
