### PR TITLE
test(parser): bucket ssh negotiation failures

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -669,6 +669,10 @@ std::string classify_unknown_auth_pattern(const Event& event) {
             return "sshd_timeout_or_disconnection";
         }
 
+        if (message.starts_with("Unable to negotiate with ")) {
+            return "sshd_negotiation_failure";
+        }
+
         return "sshd_other";
     }
 

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -695,9 +695,9 @@ void test_syslog_fixture_matrix_file() {
     expect(result.quality.top_unknown_patterns[2].pattern == "pam_unix_other",
            "expected unsupported pam_unix syslog bucket");
     expect(result.quality.top_unknown_patterns[2].count == 1, "expected one unsupported pam_unix syslog line");
-    expect(result.quality.top_unknown_patterns[3].pattern == "sshd_other",
-           "expected unsupported sshd syslog bucket");
-    expect(result.quality.top_unknown_patterns[3].count == 1, "expected one unsupported sshd syslog line");
+    expect(result.quality.top_unknown_patterns[3].pattern == "sshd_negotiation_failure",
+           "expected sshd negotiation-failure syslog bucket");
+    expect(result.quality.top_unknown_patterns[3].count == 1, "expected one sshd negotiation-failure syslog line");
 }
 
 void test_journalctl_fixture_matrix_file() {
@@ -759,9 +759,9 @@ void test_journalctl_fixture_matrix_file() {
     expect(result.quality.top_unknown_patterns[2].pattern == "pam_unix_other",
            "expected unsupported pam_unix journalctl bucket");
     expect(result.quality.top_unknown_patterns[2].count == 1, "expected one unsupported pam_unix journalctl line");
-    expect(result.quality.top_unknown_patterns[3].pattern == "sshd_other",
-           "expected unsupported sshd journalctl bucket");
-    expect(result.quality.top_unknown_patterns[3].count == 1, "expected one unsupported sshd journalctl line");
+    expect(result.quality.top_unknown_patterns[3].pattern == "sshd_negotiation_failure",
+           "expected sshd negotiation-failure journalctl bucket");
+    expect(result.quality.top_unknown_patterns[3].count == 1, "expected one sshd negotiation-failure journalctl line");
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- add a stable `sshd_negotiation_failure` unknown-pattern bucket for unsupported SSH negotiation failures
- keep the line as parser telemetry instead of promoting it to a detector finding
- update syslog and journalctl fixture-matrix expectations

## Validation
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe' --build build --config Debug --target test_parser`
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe' --test-dir build -C Debug -R parser --output-on-failure`
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe' --build build --config Debug`
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe' --test-dir build -C Debug --output-on-failure`