### PR TITLE
test(parser): bucket pam session closures

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -677,6 +677,10 @@ std::string classify_unknown_auth_pattern(const Event& event) {
     }
 
     if (event.program.starts_with("pam_unix(")) {
+        if (message.starts_with("session closed for user ")) {
+            return "pam_unix_session_closed";
+        }
+
         return "pam_unix_other";
     }
 

--- a/tests/test_detector.cpp
+++ b/tests/test_detector.cpp
@@ -260,8 +260,8 @@ void test_unsupported_pam_session_close_remains_telemetry_only() {
     expect(result.events.empty(), "expected unsupported session-close line to stay out of parsed events");
     expect(result.warnings.size() == 1, "expected unsupported session-close line to produce one warning");
     expect(result.quality.top_unknown_patterns.size() == 1, "expected one unknown pattern bucket");
-    expect(result.quality.top_unknown_patterns.front().pattern == "pam_unix_other",
-           "expected unsupported session-close line to remain in pam_unix_other telemetry");
+    expect(result.quality.top_unknown_patterns.front().pattern == "pam_unix_session_closed",
+           "expected unsupported session-close line to remain in session-closed telemetry");
 
     const auto signals = loglens::build_auth_signals(result.events, loglens::DetectorConfig{}.auth_signal_mappings);
     expect(signals.empty(), "expected unsupported session-close line to stay out of the signal layer");

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -466,9 +466,9 @@ void test_syslog_auth_family_fixture_file() {
     expect(result.quality.top_unknown_patterns[3].pattern == "pam_sss_unknown_user",
            "expected pam_sss unknown-user telemetry bucket");
     expect(result.quality.top_unknown_patterns[3].count == 1, "expected one pam_sss unknown-user line");
-    expect(result.quality.top_unknown_patterns[4].pattern == "pam_unix_other",
-           "expected pam_unix other telemetry bucket");
-    expect(result.quality.top_unknown_patterns[4].count == 1, "expected one pam_unix other line");
+    expect(result.quality.top_unknown_patterns[4].pattern == "pam_unix_session_closed",
+           "expected pam_unix session-closed telemetry bucket");
+    expect(result.quality.top_unknown_patterns[4].count == 1, "expected one pam_unix session-closed line");
 }
 
 void test_journalctl_auth_family_fixture_file() {
@@ -515,9 +515,9 @@ void test_journalctl_auth_family_fixture_file() {
     expect(result.quality.top_unknown_patterns[3].pattern == "pam_sss_unknown_user",
            "expected journalctl pam_sss unknown-user telemetry bucket");
     expect(result.quality.top_unknown_patterns[3].count == 1, "expected one journalctl pam_sss unknown-user line");
-    expect(result.quality.top_unknown_patterns[4].pattern == "pam_unix_other",
-           "expected journalctl pam_unix other telemetry bucket");
-    expect(result.quality.top_unknown_patterns[4].count == 1, "expected one journalctl pam_unix other line");
+    expect(result.quality.top_unknown_patterns[4].pattern == "pam_unix_session_closed",
+           "expected journalctl pam_unix session-closed telemetry bucket");
+    expect(result.quality.top_unknown_patterns[4].count == 1, "expected one journalctl pam_unix session-closed line");
 }
 
 void test_malformed_line() {
@@ -692,9 +692,9 @@ void test_syslog_fixture_matrix_file() {
     expect(result.quality.top_unknown_patterns[1].pattern == "sshd_timeout_or_disconnection",
            "expected timeout/disconnection syslog bucket");
     expect(result.quality.top_unknown_patterns[1].count == 3, "expected three timeout/disconnection syslog lines");
-    expect(result.quality.top_unknown_patterns[2].pattern == "pam_unix_other",
-           "expected unsupported pam_unix syslog bucket");
-    expect(result.quality.top_unknown_patterns[2].count == 1, "expected one unsupported pam_unix syslog line");
+    expect(result.quality.top_unknown_patterns[2].pattern == "pam_unix_session_closed",
+           "expected pam_unix session-closed syslog bucket");
+    expect(result.quality.top_unknown_patterns[2].count == 1, "expected one pam_unix session-closed syslog line");
     expect(result.quality.top_unknown_patterns[3].pattern == "sshd_negotiation_failure",
            "expected sshd negotiation-failure syslog bucket");
     expect(result.quality.top_unknown_patterns[3].count == 1, "expected one sshd negotiation-failure syslog line");
@@ -756,9 +756,9 @@ void test_journalctl_fixture_matrix_file() {
     expect(result.quality.top_unknown_patterns[1].pattern == "sshd_timeout_or_disconnection",
            "expected timeout/disconnection journalctl bucket");
     expect(result.quality.top_unknown_patterns[1].count == 3, "expected three timeout/disconnection journalctl lines");
-    expect(result.quality.top_unknown_patterns[2].pattern == "pam_unix_other",
-           "expected unsupported pam_unix journalctl bucket");
-    expect(result.quality.top_unknown_patterns[2].count == 1, "expected one unsupported pam_unix journalctl line");
+    expect(result.quality.top_unknown_patterns[2].pattern == "pam_unix_session_closed",
+           "expected pam_unix session-closed journalctl bucket");
+    expect(result.quality.top_unknown_patterns[2].count == 1, "expected one pam_unix session-closed journalctl line");
     expect(result.quality.top_unknown_patterns[3].pattern == "sshd_negotiation_failure",
            "expected sshd negotiation-failure journalctl bucket");
     expect(result.quality.top_unknown_patterns[3].count == 1, "expected one sshd negotiation-failure journalctl line");


### PR DESCRIPTION
## Summary
- add a stable `pam_unix_session_closed` unknown-pattern bucket for unsupported PAM session-close lines
- keep session-close evidence out of parsed events and detector signals
- update parser and detector boundary tests for syslog and journalctl fixtures

## Validation
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe' --build build --config Debug --target test_parser`
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe' --test-dir build -C Debug -R parser --output-on-failure`
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe' --build build --config Debug --target test_detector`
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe' --test-dir build -C Debug -R detector --output-on-failure`
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe' --test-dir build -C Debug --output-on-failure`
- `& 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe' --build build --config Debug`