### PR TITLE
docs(parser): document telemetry buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ LogLens also tracks parser coverage telemetry for unsupported or malformed lines
 - `parse_success_rate`
 - `top_unknown_patterns`
 
+Common unsupported-pattern buckets include `sshd_connection_closed_preauth`,
+`sshd_timeout_or_disconnection`, `sshd_negotiation_failure`, and
+`pam_unix_session_closed`. These buckets keep non-finding evidence reviewable
+without counting it as detector evidence.
+
 For the parser behavior contract, supported modes, and fixture map, see [`docs/parser-contract.md`](./docs/parser-contract.md).
 
 LogLens does not currently detect:

--- a/docs/parser-contract.md
+++ b/docs/parser-contract.md
@@ -41,6 +41,12 @@ Recognized success or audit families include accepted password, accepted publick
 
 This is the main trust boundary: unsupported input should remain inspectable, even when it does not produce a finding.
 
+Stable unsupported-pattern buckets currently exercised by the fixture corpus include
+`sshd_connection_closed_preauth`, `sshd_timeout_or_disconnection`,
+`sshd_negotiation_failure`, and `pam_unix_session_closed`. They are parser
+telemetry and warnings only; detector signal mappings decide which parsed events
+can contribute to findings.
+
 ## Detection signal boundary
 
 Parsing a line does not automatically mean it should drive a detector. LogLens keeps that boundary explicit through `AuthSignalConfig`.


### PR DESCRIPTION
## Summary
- document stable unsupported-pattern telemetry buckets in README
- clarify that unsupported-pattern buckets are parser warnings/telemetry, not detector findings
- address the Codex review comment on PR #43

## Validation
- git diff --check
- ctest --test-dir build -C Debug --output-on-failure