### PR TITLE
test(report): cover session-close telemetry artifact

### DIFF
--- a/tests/fixtures/report_contracts/multi_host_journalctl_short_full/input.log
+++ b/tests/fixtures/report_contracts/multi_host_journalctl_short_full/input.log
@@ -13,3 +13,4 @@ Wed 2026-03-11 09:13:38 UTC beta-host pam_sss(sshd:auth): received for user ghos
 Wed 2026-03-11 09:14:15 UTC beta-host sudo:    alice : TTY=pts/0 ; PWD=/home/alice ; USER=root ; COMMAND=/usr/bin/vi /etc/ssh/sshd_config
 Wed 2026-03-11 09:15:12 UTC alpha-host sshd[2307]: Connection closed by authenticating user alice 203.0.113.50 port 52290 [preauth]
 Wed 2026-03-11 09:16:18 UTC beta-host sshd[2402]: Timeout, client not responding from 203.0.113.51 port 52291
+Wed 2026-03-11 09:17:24 UTC beta-host pam_unix(sshd:session): session closed for user alice

--- a/tests/fixtures/report_contracts/multi_host_journalctl_short_full/report.json
+++ b/tests/fixtures/report_contracts/multi_host_journalctl_short_full/report.json
@@ -4,20 +4,21 @@
   "input_mode": "journalctl_short_full",
   "timezone_present": true,
   "parser_quality": {
-    "total_input_lines": 15,
-    "total_lines": 15,
+    "total_input_lines": 16,
+    "total_lines": 16,
     "skipped_blank_lines": 0,
     "parsed_lines": 12,
-    "unparsed_lines": 3,
-    "parse_success_rate": 0.8000,
+    "unparsed_lines": 4,
+    "parse_success_rate": 0.7500,
     "top_unknown_patterns": [
       {"pattern": "pam_sss_unknown_user", "count": 1},
+      {"pattern": "pam_unix_session_closed", "count": 1},
       {"pattern": "sshd_connection_closed_preauth", "count": 1},
       {"pattern": "sshd_timeout_or_disconnection", "count": 1}
     ]
   },
   "parsed_event_count": 12,
-  "warning_count": 3,
+  "warning_count": 4,
   "finding_count": 3,
   "event_counts": [
     {"event_type": "ssh_failed_password", "count": 3},
@@ -44,7 +45,7 @@
       "hostname": "beta-host",
       "parsed_event_count": 5,
       "finding_count": 1,
-      "warning_count": 2,
+      "warning_count": 3,
       "event_counts": [
         {"event_type": "ssh_accepted_publickey", "count": 1},
         {"event_type": "pam_auth_failure", "count": 1},
@@ -87,6 +88,7 @@
   "warnings": [
     {"line_number": 12, "reason": "unrecognized auth pattern: pam_sss_unknown_user"},
     {"line_number": 14, "reason": "unrecognized auth pattern: sshd_connection_closed_preauth"},
-    {"line_number": 15, "reason": "unrecognized auth pattern: sshd_timeout_or_disconnection"}
+    {"line_number": 15, "reason": "unrecognized auth pattern: sshd_timeout_or_disconnection"},
+    {"line_number": 16, "reason": "unrecognized auth pattern: pam_unix_session_closed"}
   ]
 }

--- a/tests/fixtures/report_contracts/multi_host_journalctl_short_full/report.md
+++ b/tests/fixtures/report_contracts/multi_host_journalctl_short_full/report.md
@@ -5,22 +5,22 @@
 - Input: `tests/fixtures/report_contracts/multi_host_journalctl_short_full/input.log`
 - Input mode: journalctl_short_full
 - Timezone present: true
-- Total input lines: 15
-- Total lines: 15
+- Total input lines: 16
+- Total lines: 16
 - Skipped blank lines: 0
 - Parsed lines: 12
-- Unparsed lines: 3
-- Parse success rate: 80.00%
+- Unparsed lines: 4
+- Parse success rate: 75.00%
 - Parsed events: 12
 - Findings: 3
-- Parser warnings: 3
+- Parser warnings: 4
 
 ## Host Summary
 
 | Host | Parsed Events | Findings | Warnings |
 | --- | ---: | ---: | ---: |
 | alpha-host | 7 | 2 | 1 |
-| beta-host | 5 | 1 | 2 |
+| beta-host | 5 | 1 | 3 |
 
 ## Findings
 
@@ -46,6 +46,7 @@
 | Unknown Pattern | Count |
 | --- | ---: |
 | pam_sss_unknown_user | 1 |
+| pam_unix_session_closed | 1 |
 | sshd_connection_closed_preauth | 1 |
 | sshd_timeout_or_disconnection | 1 |
 
@@ -56,3 +57,4 @@
 | 12 | unrecognized auth pattern: pam_sss_unknown_user |
 | 14 | unrecognized auth pattern: sshd_connection_closed_preauth |
 | 15 | unrecognized auth pattern: sshd_timeout_or_disconnection |
+| 16 | unrecognized auth pattern: pam_unix_session_closed |

--- a/tests/fixtures/report_contracts/multi_host_syslog_legacy/input.log
+++ b/tests/fixtures/report_contracts/multi_host_syslog_legacy/input.log
@@ -13,3 +13,4 @@ Mar 11 09:13:38 beta-host pam_sss(sshd:auth): received for user ghost: 10 (User 
 Mar 11 09:14:15 beta-host sudo:    alice : TTY=pts/0 ; PWD=/home/alice ; USER=root ; COMMAND=/usr/bin/vi /etc/ssh/sshd_config
 Mar 11 09:15:12 alpha-host sshd[1307]: Connection closed by authenticating user alice 203.0.113.50 port 52290 [preauth]
 Mar 11 09:16:18 beta-host sshd[1402]: Timeout, client not responding from 203.0.113.51 port 52291
+Mar 11 09:17:24 beta-host pam_unix(sshd:session): session closed for user alice

--- a/tests/fixtures/report_contracts/multi_host_syslog_legacy/report.json
+++ b/tests/fixtures/report_contracts/multi_host_syslog_legacy/report.json
@@ -5,20 +5,21 @@
   "assume_year": 2026,
   "timezone_present": false,
   "parser_quality": {
-    "total_input_lines": 15,
-    "total_lines": 15,
+    "total_input_lines": 16,
+    "total_lines": 16,
     "skipped_blank_lines": 0,
     "parsed_lines": 12,
-    "unparsed_lines": 3,
-    "parse_success_rate": 0.8000,
+    "unparsed_lines": 4,
+    "parse_success_rate": 0.7500,
     "top_unknown_patterns": [
       {"pattern": "pam_sss_unknown_user", "count": 1},
+      {"pattern": "pam_unix_session_closed", "count": 1},
       {"pattern": "sshd_connection_closed_preauth", "count": 1},
       {"pattern": "sshd_timeout_or_disconnection", "count": 1}
     ]
   },
   "parsed_event_count": 12,
-  "warning_count": 3,
+  "warning_count": 4,
   "finding_count": 3,
   "event_counts": [
     {"event_type": "ssh_failed_password", "count": 3},
@@ -45,7 +46,7 @@
       "hostname": "beta-host",
       "parsed_event_count": 5,
       "finding_count": 1,
-      "warning_count": 2,
+      "warning_count": 3,
       "event_counts": [
         {"event_type": "ssh_accepted_publickey", "count": 1},
         {"event_type": "pam_auth_failure", "count": 1},
@@ -88,6 +89,7 @@
   "warnings": [
     {"line_number": 12, "reason": "unrecognized auth pattern: pam_sss_unknown_user"},
     {"line_number": 14, "reason": "unrecognized auth pattern: sshd_connection_closed_preauth"},
-    {"line_number": 15, "reason": "unrecognized auth pattern: sshd_timeout_or_disconnection"}
+    {"line_number": 15, "reason": "unrecognized auth pattern: sshd_timeout_or_disconnection"},
+    {"line_number": 16, "reason": "unrecognized auth pattern: pam_unix_session_closed"}
   ]
 }

--- a/tests/fixtures/report_contracts/multi_host_syslog_legacy/report.md
+++ b/tests/fixtures/report_contracts/multi_host_syslog_legacy/report.md
@@ -6,22 +6,22 @@
 - Input mode: syslog_legacy
 - Assume year: 2026
 - Timezone present: false
-- Total input lines: 15
-- Total lines: 15
+- Total input lines: 16
+- Total lines: 16
 - Skipped blank lines: 0
 - Parsed lines: 12
-- Unparsed lines: 3
-- Parse success rate: 80.00%
+- Unparsed lines: 4
+- Parse success rate: 75.00%
 - Parsed events: 12
 - Findings: 3
-- Parser warnings: 3
+- Parser warnings: 4
 
 ## Host Summary
 
 | Host | Parsed Events | Findings | Warnings |
 | --- | ---: | ---: | ---: |
 | alpha-host | 7 | 2 | 1 |
-| beta-host | 5 | 1 | 2 |
+| beta-host | 5 | 1 | 3 |
 
 ## Findings
 
@@ -47,6 +47,7 @@
 | Unknown Pattern | Count |
 | --- | ---: |
 | pam_sss_unknown_user | 1 |
+| pam_unix_session_closed | 1 |
 | sshd_connection_closed_preauth | 1 |
 | sshd_timeout_or_disconnection | 1 |
 
@@ -57,3 +58,4 @@
 | 12 | unrecognized auth pattern: pam_sss_unknown_user |
 | 14 | unrecognized auth pattern: sshd_connection_closed_preauth |
 | 15 | unrecognized auth pattern: sshd_timeout_or_disconnection |
+| 16 | unrecognized auth pattern: pam_unix_session_closed |

--- a/tests/fixtures/report_contracts/multi_host_syslog_legacy/warnings.csv
+++ b/tests/fixtures/report_contracts/multi_host_syslog_legacy/warnings.csv
@@ -2,3 +2,4 @@ kind,line_number,message
 parse_warning,12,unrecognized auth pattern: pam_sss_unknown_user
 parse_warning,14,unrecognized auth pattern: sshd_connection_closed_preauth
 parse_warning,15,unrecognized auth pattern: sshd_timeout_or_disconnection
+parse_warning,16,unrecognized auth pattern: pam_unix_session_closed


### PR DESCRIPTION
## Summary
- add pam_unix session-close telemetry to multi-host report contract inputs
- update Markdown, JSON, and warnings CSV golden artifacts
- keep parsed event and finding counts unchanged while warning telemetry increases

## Validation
- ctest --test-dir build -C Debug -R report_contracts --output-on-failure
- ctest --test-dir build -C Debug --output-on-failure
- git diff --check
- added-line privacy/secret scan