### PR TITLE
test(report): cover negotiation telemetry artifact

### DIFF
--- a/tests/fixtures/report_contracts/multi_host_journalctl_short_full/input.log
+++ b/tests/fixtures/report_contracts/multi_host_journalctl_short_full/input.log
@@ -14,3 +14,4 @@ Wed 2026-03-11 09:14:15 UTC beta-host sudo:    alice : TTY=pts/0 ; PWD=/home/ali
 Wed 2026-03-11 09:15:12 UTC alpha-host sshd[2307]: Connection closed by authenticating user alice 203.0.113.50 port 52290 [preauth]
 Wed 2026-03-11 09:16:18 UTC beta-host sshd[2402]: Timeout, client not responding from 203.0.113.51 port 52291
 Wed 2026-03-11 09:17:24 UTC beta-host pam_unix(sshd:session): session closed for user alice
+Wed 2026-03-11 09:18:32 UTC alpha-host sshd[2308]: Unable to negotiate with 203.0.113.52 port 52292: no matching host key type found. Their offer: ssh-rsa

--- a/tests/fixtures/report_contracts/multi_host_journalctl_short_full/report.json
+++ b/tests/fixtures/report_contracts/multi_host_journalctl_short_full/report.json
@@ -4,21 +4,22 @@
   "input_mode": "journalctl_short_full",
   "timezone_present": true,
   "parser_quality": {
-    "total_input_lines": 16,
-    "total_lines": 16,
+    "total_input_lines": 17,
+    "total_lines": 17,
     "skipped_blank_lines": 0,
     "parsed_lines": 12,
-    "unparsed_lines": 4,
-    "parse_success_rate": 0.7500,
+    "unparsed_lines": 5,
+    "parse_success_rate": 0.7059,
     "top_unknown_patterns": [
       {"pattern": "pam_sss_unknown_user", "count": 1},
       {"pattern": "pam_unix_session_closed", "count": 1},
       {"pattern": "sshd_connection_closed_preauth", "count": 1},
+      {"pattern": "sshd_negotiation_failure", "count": 1},
       {"pattern": "sshd_timeout_or_disconnection", "count": 1}
     ]
   },
   "parsed_event_count": 12,
-  "warning_count": 4,
+  "warning_count": 5,
   "finding_count": 3,
   "event_counts": [
     {"event_type": "ssh_failed_password", "count": 3},
@@ -33,7 +34,7 @@
       "hostname": "alpha-host",
       "parsed_event_count": 7,
       "finding_count": 2,
-      "warning_count": 1,
+      "warning_count": 2,
       "event_counts": [
         {"event_type": "ssh_failed_password", "count": 3},
         {"event_type": "ssh_accepted_password", "count": 1},
@@ -89,6 +90,7 @@
     {"line_number": 12, "reason": "unrecognized auth pattern: pam_sss_unknown_user"},
     {"line_number": 14, "reason": "unrecognized auth pattern: sshd_connection_closed_preauth"},
     {"line_number": 15, "reason": "unrecognized auth pattern: sshd_timeout_or_disconnection"},
-    {"line_number": 16, "reason": "unrecognized auth pattern: pam_unix_session_closed"}
+    {"line_number": 16, "reason": "unrecognized auth pattern: pam_unix_session_closed"},
+    {"line_number": 17, "reason": "unrecognized auth pattern: sshd_negotiation_failure"}
   ]
 }

--- a/tests/fixtures/report_contracts/multi_host_journalctl_short_full/report.md
+++ b/tests/fixtures/report_contracts/multi_host_journalctl_short_full/report.md
@@ -5,21 +5,21 @@
 - Input: `tests/fixtures/report_contracts/multi_host_journalctl_short_full/input.log`
 - Input mode: journalctl_short_full
 - Timezone present: true
-- Total input lines: 16
-- Total lines: 16
+- Total input lines: 17
+- Total lines: 17
 - Skipped blank lines: 0
 - Parsed lines: 12
-- Unparsed lines: 4
-- Parse success rate: 75.00%
+- Unparsed lines: 5
+- Parse success rate: 70.59%
 - Parsed events: 12
 - Findings: 3
-- Parser warnings: 4
+- Parser warnings: 5
 
 ## Host Summary
 
 | Host | Parsed Events | Findings | Warnings |
 | --- | ---: | ---: | ---: |
-| alpha-host | 7 | 2 | 1 |
+| alpha-host | 7 | 2 | 2 |
 | beta-host | 5 | 1 | 3 |
 
 ## Findings
@@ -48,6 +48,7 @@
 | pam_sss_unknown_user | 1 |
 | pam_unix_session_closed | 1 |
 | sshd_connection_closed_preauth | 1 |
+| sshd_negotiation_failure | 1 |
 | sshd_timeout_or_disconnection | 1 |
 
 ## Parser Warnings
@@ -58,3 +59,4 @@
 | 14 | unrecognized auth pattern: sshd_connection_closed_preauth |
 | 15 | unrecognized auth pattern: sshd_timeout_or_disconnection |
 | 16 | unrecognized auth pattern: pam_unix_session_closed |
+| 17 | unrecognized auth pattern: sshd_negotiation_failure |

--- a/tests/fixtures/report_contracts/multi_host_syslog_legacy/input.log
+++ b/tests/fixtures/report_contracts/multi_host_syslog_legacy/input.log
@@ -14,3 +14,4 @@ Mar 11 09:14:15 beta-host sudo:    alice : TTY=pts/0 ; PWD=/home/alice ; USER=ro
 Mar 11 09:15:12 alpha-host sshd[1307]: Connection closed by authenticating user alice 203.0.113.50 port 52290 [preauth]
 Mar 11 09:16:18 beta-host sshd[1402]: Timeout, client not responding from 203.0.113.51 port 52291
 Mar 11 09:17:24 beta-host pam_unix(sshd:session): session closed for user alice
+Mar 11 09:18:32 alpha-host sshd[1308]: Unable to negotiate with 203.0.113.52 port 52292: no matching host key type found. Their offer: ssh-rsa

--- a/tests/fixtures/report_contracts/multi_host_syslog_legacy/report.json
+++ b/tests/fixtures/report_contracts/multi_host_syslog_legacy/report.json
@@ -5,21 +5,22 @@
   "assume_year": 2026,
   "timezone_present": false,
   "parser_quality": {
-    "total_input_lines": 16,
-    "total_lines": 16,
+    "total_input_lines": 17,
+    "total_lines": 17,
     "skipped_blank_lines": 0,
     "parsed_lines": 12,
-    "unparsed_lines": 4,
-    "parse_success_rate": 0.7500,
+    "unparsed_lines": 5,
+    "parse_success_rate": 0.7059,
     "top_unknown_patterns": [
       {"pattern": "pam_sss_unknown_user", "count": 1},
       {"pattern": "pam_unix_session_closed", "count": 1},
       {"pattern": "sshd_connection_closed_preauth", "count": 1},
+      {"pattern": "sshd_negotiation_failure", "count": 1},
       {"pattern": "sshd_timeout_or_disconnection", "count": 1}
     ]
   },
   "parsed_event_count": 12,
-  "warning_count": 4,
+  "warning_count": 5,
   "finding_count": 3,
   "event_counts": [
     {"event_type": "ssh_failed_password", "count": 3},
@@ -34,7 +35,7 @@
       "hostname": "alpha-host",
       "parsed_event_count": 7,
       "finding_count": 2,
-      "warning_count": 1,
+      "warning_count": 2,
       "event_counts": [
         {"event_type": "ssh_failed_password", "count": 3},
         {"event_type": "ssh_accepted_password", "count": 1},
@@ -90,6 +91,7 @@
     {"line_number": 12, "reason": "unrecognized auth pattern: pam_sss_unknown_user"},
     {"line_number": 14, "reason": "unrecognized auth pattern: sshd_connection_closed_preauth"},
     {"line_number": 15, "reason": "unrecognized auth pattern: sshd_timeout_or_disconnection"},
-    {"line_number": 16, "reason": "unrecognized auth pattern: pam_unix_session_closed"}
+    {"line_number": 16, "reason": "unrecognized auth pattern: pam_unix_session_closed"},
+    {"line_number": 17, "reason": "unrecognized auth pattern: sshd_negotiation_failure"}
   ]
 }

--- a/tests/fixtures/report_contracts/multi_host_syslog_legacy/report.md
+++ b/tests/fixtures/report_contracts/multi_host_syslog_legacy/report.md
@@ -6,21 +6,21 @@
 - Input mode: syslog_legacy
 - Assume year: 2026
 - Timezone present: false
-- Total input lines: 16
-- Total lines: 16
+- Total input lines: 17
+- Total lines: 17
 - Skipped blank lines: 0
 - Parsed lines: 12
-- Unparsed lines: 4
-- Parse success rate: 75.00%
+- Unparsed lines: 5
+- Parse success rate: 70.59%
 - Parsed events: 12
 - Findings: 3
-- Parser warnings: 4
+- Parser warnings: 5
 
 ## Host Summary
 
 | Host | Parsed Events | Findings | Warnings |
 | --- | ---: | ---: | ---: |
-| alpha-host | 7 | 2 | 1 |
+| alpha-host | 7 | 2 | 2 |
 | beta-host | 5 | 1 | 3 |
 
 ## Findings
@@ -49,6 +49,7 @@
 | pam_sss_unknown_user | 1 |
 | pam_unix_session_closed | 1 |
 | sshd_connection_closed_preauth | 1 |
+| sshd_negotiation_failure | 1 |
 | sshd_timeout_or_disconnection | 1 |
 
 ## Parser Warnings
@@ -59,3 +60,4 @@
 | 14 | unrecognized auth pattern: sshd_connection_closed_preauth |
 | 15 | unrecognized auth pattern: sshd_timeout_or_disconnection |
 | 16 | unrecognized auth pattern: pam_unix_session_closed |
+| 17 | unrecognized auth pattern: sshd_negotiation_failure |

--- a/tests/fixtures/report_contracts/multi_host_syslog_legacy/warnings.csv
+++ b/tests/fixtures/report_contracts/multi_host_syslog_legacy/warnings.csv
@@ -3,3 +3,4 @@ parse_warning,12,unrecognized auth pattern: pam_sss_unknown_user
 parse_warning,14,unrecognized auth pattern: sshd_connection_closed_preauth
 parse_warning,15,unrecognized auth pattern: sshd_timeout_or_disconnection
 parse_warning,16,unrecognized auth pattern: pam_unix_session_closed
+parse_warning,17,unrecognized auth pattern: sshd_negotiation_failure


### PR DESCRIPTION
## Summary
- add sshd negotiation-failure telemetry to multi-host report contract inputs
- update Markdown, JSON, and warnings CSV golden artifacts
- keep parsed event and finding counts unchanged while warning telemetry increases

## Validation
- ctest --test-dir build -C Debug -R report_contracts --output-on-failure
- ctest --test-dir build -C Debug --output-on-failure
- git diff --check
- added-line privacy/secret scan