### PR TITLE
Bucket PAM faillock account-lock telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ LogLens also tracks parser coverage telemetry for unsupported or malformed lines
 - `top_unknown_patterns`
 
 Common unsupported-pattern buckets include `sshd_connection_closed_preauth`,
-`sshd_timeout_or_disconnection`, `sshd_negotiation_failure`, and
-`pam_unix_session_closed`. These buckets keep non-finding evidence reviewable
-without counting it as detector evidence.
+`sshd_timeout_or_disconnection`, `sshd_negotiation_failure`,
+`pam_faillock_account_locked`, and `pam_unix_session_closed`. These buckets keep
+non-finding evidence reviewable without counting it as detector evidence.
 
 For the parser behavior contract, supported modes, and fixture map, see [`docs/parser-contract.md`](./docs/parser-contract.md).
 

--- a/docs/parser-contract.md
+++ b/docs/parser-contract.md
@@ -43,9 +43,9 @@ This is the main trust boundary: unsupported input should remain inspectable, ev
 
 Stable unsupported-pattern buckets currently exercised by the fixture corpus include
 `sshd_connection_closed_preauth`, `sshd_timeout_or_disconnection`,
-`sshd_negotiation_failure`, and `pam_unix_session_closed`. They are parser
-telemetry and warnings only; detector signal mappings decide which parsed events
-can contribute to findings.
+`sshd_negotiation_failure`, `pam_faillock_account_locked`, and
+`pam_unix_session_closed`. They are parser telemetry and warnings only; detector
+signal mappings decide which parsed events can contribute to findings.
 
 ## Detection signal boundary
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -700,6 +700,10 @@ bool parse_pam_faillock_message(std::string_view message, Event& event) {
 }
 
 std::string classify_unknown_pam_faillock_pattern(std::string_view message) {
+    if (message.starts_with("Account temporarily locked for user ")) {
+        return "pam_faillock_account_locked";
+    }
+
     if (message.starts_with("User ") && message.find("successfully authenticated") != std::string_view::npos) {
         return "pam_faillock_authsucc";
     }

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -8,6 +9,7 @@ namespace {
 
 void expect(bool condition, const std::string& message) {
     if (!condition) {
+        std::cerr << "test_cli assertion failed: " << message << '\n';
         throw std::runtime_error(message);
     }
 }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -605,12 +605,12 @@ void test_syslog_auth_family_fixture_file() {
     expect(result.events[11].username == "erin", "expected pam_unix session-opened username");
 
     expect(result.quality.top_unknown_patterns.size() == 5, "expected five syslog auth-family buckets");
-    expect(result.quality.top_unknown_patterns[0].pattern == "pam_faillock_authsucc",
+    expect(result.quality.top_unknown_patterns[0].pattern == "pam_faillock_account_locked",
+           "expected pam_faillock account-locked telemetry bucket");
+    expect(result.quality.top_unknown_patterns[0].count == 1, "expected one pam_faillock account-locked line");
+    expect(result.quality.top_unknown_patterns[1].pattern == "pam_faillock_authsucc",
            "expected pam_faillock authsucc telemetry bucket");
-    expect(result.quality.top_unknown_patterns[0].count == 1, "expected one pam_faillock authsucc line");
-    expect(result.quality.top_unknown_patterns[1].pattern == "pam_faillock_other",
-           "expected pam_faillock other telemetry bucket");
-    expect(result.quality.top_unknown_patterns[1].count == 1, "expected one pam_faillock other line");
+    expect(result.quality.top_unknown_patterns[1].count == 1, "expected one pam_faillock authsucc line");
     expect(result.quality.top_unknown_patterns[2].pattern == "pam_sss_authinfo_unavail",
            "expected pam_sss authinfo-unavail telemetry bucket");
     expect(result.quality.top_unknown_patterns[2].count == 1, "expected one pam_sss authinfo-unavail line");
@@ -671,12 +671,13 @@ void test_journalctl_auth_family_fixture_file() {
            "expected journalctl pam_unix session-opened auth-family event");
 
     expect(result.quality.top_unknown_patterns.size() == 5, "expected five journalctl auth-family buckets");
-    expect(result.quality.top_unknown_patterns[0].pattern == "pam_faillock_authsucc",
+    expect(result.quality.top_unknown_patterns[0].pattern == "pam_faillock_account_locked",
+           "expected journalctl pam_faillock account-locked telemetry bucket");
+    expect(result.quality.top_unknown_patterns[0].count == 1,
+           "expected one journalctl pam_faillock account-locked line");
+    expect(result.quality.top_unknown_patterns[1].pattern == "pam_faillock_authsucc",
            "expected journalctl pam_faillock authsucc telemetry bucket");
-    expect(result.quality.top_unknown_patterns[0].count == 1, "expected one journalctl pam_faillock authsucc line");
-    expect(result.quality.top_unknown_patterns[1].pattern == "pam_faillock_other",
-           "expected journalctl pam_faillock other telemetry bucket");
-    expect(result.quality.top_unknown_patterns[1].count == 1, "expected one journalctl pam_faillock other line");
+    expect(result.quality.top_unknown_patterns[1].count == 1, "expected one journalctl pam_faillock authsucc line");
     expect(result.quality.top_unknown_patterns[2].pattern == "pam_sss_authinfo_unavail",
            "expected journalctl pam_sss authinfo-unavail telemetry bucket");
     expect(result.quality.top_unknown_patterns[2].count == 1, "expected one journalctl pam_sss authinfo-unavail line");


### PR DESCRIPTION
## Summary
- split `pam_faillock(...): Account temporarily locked for user ...` into the stable `pam_faillock_account_locked` telemetry bucket instead of the generic `pam_faillock_other` bucket
- update parser fixture assertions and docs so unsupported account-lock evidence remains reviewable without becoming detector evidence
- print `test_cli` assertion messages to stderr so Windows CLI test failures are diagnosable in CI output

## Validation
- `cmake --build build --config Debug --target test_parser`
- `ctest --test-dir build -C Debug -R parser --output-on-failure`
- `cmake --build build --config Debug`
- `ctest --test-dir build -C Debug --output-on-failure`
- `git diff --check`
- diff scans for local paths, secret assignment patterns, private-key markers, and non-documentation IP addresses

## Safety
- No new parsed event type or detector signal mapping.
- This remains telemetry-only for unsupported `pam_faillock` account-lock lines.
- Existing fixture lines use `example-host` and `203.0.113.x` documentation addresses only.