### PR TITLE
test(report): lock golden report fixtures

### DIFF
--- a/docs/report-artifacts.md
+++ b/docs/report-artifacts.md
@@ -61,11 +61,11 @@ The report contracts are backed by generated fixture artifacts:
 | Fixture case | Golden artifacts |
 | --- | --- |
 | [`syslog_legacy`](../tests/fixtures/report_contracts/syslog_legacy) | `report.md`, `report.json`, `findings.csv`, `warnings.csv` |
-| [`journalctl_short_full`](../tests/fixtures/report_contracts/journalctl_short_full) | `report.md`, `report.json` |
+| [`journalctl_short_full`](../tests/fixtures/report_contracts/journalctl_short_full) | `report.md`, `report.json`, `findings.csv`, `warnings.csv` |
 | [`multi_host_syslog_legacy`](../tests/fixtures/report_contracts/multi_host_syslog_legacy) | `report.md`, `report.json`, `findings.csv`, `warnings.csv` |
-| [`multi_host_journalctl_short_full`](../tests/fixtures/report_contracts/multi_host_journalctl_short_full) | `report.md`, `report.json` |
+| [`multi_host_journalctl_short_full`](../tests/fixtures/report_contracts/multi_host_journalctl_short_full) | `report.md`, `report.json`, `findings.csv`, `warnings.csv` |
 
-The enforcement lives in [`tests/test_report_contracts.cpp`](../tests/test_report_contracts.cpp). The focused report writer tests live in [`tests/test_report.cpp`](../tests/test_report.cpp).
+The enforcement lives in [`tests/test_report_contracts.cpp`](../tests/test_report_contracts.cpp). Parser or rule changes that alter report artifacts must update these snapshots explicitly. The focused report writer tests live in [`tests/test_report.cpp`](../tests/test_report.cpp).
 
 ## Boundaries
 

--- a/tests/fixtures/report_contracts/journalctl_short_full/findings.csv
+++ b/tests/fixtures/report_contracts/journalctl_short_full/findings.csv
@@ -1,0 +1,4 @@
+rule,subject_kind,subject,event_count,window_start,window_end,usernames,summary
+brute_force,source_ip,203.0.113.10,5,2026-03-10 08:11:22,2026-03-10 08:18:05,,5 failed SSH attempts from 203.0.113.10 within 10 minutes.
+multi_user_probing,source_ip,203.0.113.10,5,2026-03-10 08:11:22,2026-03-10 08:18:05,admin;deploy;guest;root;test,203.0.113.10 targeted 5 usernames within 15 minutes.
+sudo_burst,username,alice,3,2026-03-10 08:21:00,2026-03-10 08:24:15,,alice ran 3 sudo commands within 5 minutes.

--- a/tests/fixtures/report_contracts/journalctl_short_full/warnings.csv
+++ b/tests/fixtures/report_contracts/journalctl_short_full/warnings.csv
@@ -1,0 +1,3 @@
+kind,line_number,message
+parse_warning,15,unrecognized auth pattern: sshd_connection_closed_preauth
+parse_warning,16,unrecognized auth pattern: sshd_timeout_or_disconnection

--- a/tests/fixtures/report_contracts/multi_host_journalctl_short_full/findings.csv
+++ b/tests/fixtures/report_contracts/multi_host_journalctl_short_full/findings.csv
@@ -1,0 +1,4 @@
+rule,subject_kind,subject,event_count,window_start,window_end,usernames,summary
+brute_force,source_ip,203.0.113.10,5,2026-03-11 09:00:00,2026-03-11 09:04:05,,5 failed SSH attempts from 203.0.113.10 within 10 minutes.
+multi_user_probing,source_ip,203.0.113.10,5,2026-03-11 09:00:00,2026-03-11 09:04:05,admin;deploy;guest;root;test,203.0.113.10 targeted 5 usernames within 15 minutes.
+sudo_burst,username,alice,3,2026-03-11 09:11:00,2026-03-11 09:14:15,,alice ran 3 sudo commands within 5 minutes.

--- a/tests/fixtures/report_contracts/multi_host_journalctl_short_full/warnings.csv
+++ b/tests/fixtures/report_contracts/multi_host_journalctl_short_full/warnings.csv
@@ -1,0 +1,6 @@
+kind,line_number,message
+parse_warning,12,unrecognized auth pattern: pam_sss_unknown_user
+parse_warning,14,unrecognized auth pattern: sshd_connection_closed_preauth
+parse_warning,15,unrecognized auth pattern: sshd_timeout_or_disconnection
+parse_warning,16,unrecognized auth pattern: pam_unix_session_closed
+parse_warning,17,unrecognized auth pattern: sshd_negotiation_failure

--- a/tests/test_report_contracts.cpp
+++ b/tests/test_report_contracts.cpp
@@ -242,6 +242,14 @@ void run_report_contract_case(const std::filesystem::path& loglens_exe,
     const auto golden_json = read_file(fixture_directory / "report.json");
 
     expect_equal_lines(
+        split_lines(actual_markdown),
+        split_lines(golden_markdown),
+        "markdown snapshot mismatch for " + fixture_directory.filename().string());
+    expect_equal_lines(
+        split_lines(actual_json),
+        split_lines(golden_json),
+        "json snapshot mismatch for " + fixture_directory.filename().string());
+    expect_equal_lines(
         extract_markdown_contract_lines(actual_markdown),
         extract_markdown_contract_lines(golden_markdown),
         "markdown contract mismatch for " + fixture_directory.filename().string());
@@ -328,10 +336,24 @@ int main(int argc, char* argv[]) {
             true);
         run_report_contract_case(
             loglens_exe,
+            fixture_root / "journalctl_short_full",
+            output_root,
+            "journalctl-short-full",
+            "--csv",
+            true);
+        run_report_contract_case(
+            loglens_exe,
             fixture_root / "multi_host_syslog_legacy",
             output_root,
             "syslog",
             "--year 2026 --csv",
+            true);
+        run_report_contract_case(
+            loglens_exe,
+            fixture_root / "multi_host_journalctl_short_full",
+            output_root,
+            "journalctl-short-full",
+            "--csv",
             true);
     } catch (...) {
         std::filesystem::current_path(original_cwd);


### PR DESCRIPTION
## Summary
- add journalctl CSV golden fixtures for report contract coverage
- enforce full-file report.md and report.json snapshot comparisons
- document that parser or rule changes must update report snapshots explicitly

## Validation
- git diff --check
- cmake -S . -B build
- cmake --build build with sanitized Path/PATH environment
- ctest --test-dir build -C Debug --output-on-failure