### PR TITLE
Add README example finding summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ C++20 defensive log analysis CLI for Linux authentication logs, with parser cove
 
 It parses `auth.log` / `secure`-style syslog input and `journalctl --output=short-full`-style input, normalizes authentication evidence, applies configurable rule-based detections, and emits deterministic Markdown and JSON reports, with optional CSV exports for findings and warnings.
 
+## Example Finding
+
+A compact finding summary is a bounded triage signal, not attribution:
+
+```json
+{
+  "rule_id": "brute_force",
+  "subject_kind": "source_ip",
+  "subject": "198.51.100.23",
+  "window": "10m",
+  "threshold": 5,
+  "observed": 8,
+  "verdict_boundary": "triage_signal_not_attribution"
+}
+```
+
 ## Project Status
 
 LogLens is an MVP / early release. The repository is stable enough for public review, local experimentation, and extension, but the parser and detection coverage are intentionally narrow.


### PR DESCRIPTION
## Summary
- Add a first-screen README `Example Finding` JSON snippet
- Use a documentation-reserved source IP and an explicit triage-not-attribution boundary
- Keep the example framed as a compact summary rather than the raw report schema

## Validation
- `git diff --check main...HEAD`
- Privacy/security scan over the PR diff for local paths, private keys, common token prefixes, identity markers, and non-documentation IPv4 literals
- README-only change; CTest not run locally