### PR TITLE
chore(security): add repo sentinel hygiene gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 *.h text eol=lf
 *.md text eol=lf
 *.json text eol=lf
+*.toml text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
 *.txt text eol=lf

--- a/.github/workflows/repo-sentinel.yml
+++ b/.github/workflows/repo-sentinel.yml
@@ -17,9 +17,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.14"
+
       - name: Install repo-sentinel-lite
         run: |
-          python3 -m venv "$RUNNER_TEMP/repo-sentinel-venv"
+          python -m venv "$RUNNER_TEMP/repo-sentinel-venv"
           "$RUNNER_TEMP/repo-sentinel-venv/bin/python" -m pip install --upgrade pip
           "$RUNNER_TEMP/repo-sentinel-venv/bin/python" -m pip install repo-sentinel-lite
 

--- a/.github/workflows/repo-sentinel.yml
+++ b/.github/workflows/repo-sentinel.yml
@@ -1,0 +1,31 @@
+name: Repo Sentinel
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repo-sentinel:
+    name: Repo Sentinel
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install repo-sentinel-lite
+        run: |
+          python3 -m venv "$RUNNER_TEMP/repo-sentinel-venv"
+          "$RUNNER_TEMP/repo-sentinel-venv/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/repo-sentinel-venv/bin/python" -m pip install repo-sentinel-lite
+
+      - name: Run repository hygiene gate
+        run: |
+          "$RUNNER_TEMP/repo-sentinel-venv/bin/repo-sentinel" scan \
+            --fail-on-severity error \
+            --format text \
+            .

--- a/.reposentinel.toml
+++ b/.reposentinel.toml
@@ -1,0 +1,22 @@
+# LogLens uses repo-sentinel-lite as a narrow hygiene gate:
+# required repository files plus accidental sensitive filenames.
+#
+# High-entropy content scanning is intentionally disabled here so fixture logs
+# and C++ build outputs do not affect this gate.
+max_text_file_size = 0
+entropy_threshold = 999.0
+
+ignore_globs = [
+  "build/**",
+  "build_manual*",
+  "out/**",
+  "report.md",
+  "report.json",
+  "*.exe",
+  "CMakeFiles",
+  "CMakeFiles/**",
+  "CMakeCache.txt",
+  "cmake_install.cmake",
+  "compile_commands.json",
+  "*.vcxproj.user",
+]


### PR DESCRIPTION
## Summary
- add a narrow repo-sentinel-lite configuration for LogLens
- run repo-sentinel from production PyPI in CI on push, PR, and manual dispatch
- keep the gate focused on repository hygiene and accidental sensitive filenames, with C++ build artifacts ignored

## Validation
- `repo-sentinel scan --fail-on-severity error --format text .`
- `cmake -S . -B build\ci-release -D CMAKE_BUILD_TYPE=Release -D BUILD_TESTING=ON`
- `cmake --build build\ci-release --config Release`
- `ctest --test-dir build\ci-release --build-config Release --output-on-failure`
- `git diff --check`