### PR TITLE
docs(release): add v0.5 readiness checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable user-visible changes should be recorded here.
 ### Docs
 
 - Added release notes for the v0.5 Evidence Explainability Release.
+- Added a release readiness checklist that maps v0.5 requirements to reviewer
+  evidence and stopping points.
 - Added a one-page incident-style case that traces raw SSH evidence through
   normalized events and finding fields to a bounded conclusion.
 - Added a rule-by-rule false-positive taxonomy for NAT, bastion, internal scanner,

--- a/docs/parser-contract.md
+++ b/docs/parser-contract.md
@@ -6,6 +6,12 @@ The guiding rule is:
 
 > Parser observability > silent detection claims.
 
+For the v0.5 Evidence Explainability Release, this contract is part of the
+release-facing reviewer path. Start with [`docs/release-v0.5.0.md`](./release-v0.5.0.md)
+for the release checklist, then use this page to inspect supported inputs,
+unsupported-line handling, parser warning categories, and the detection signal
+boundary.
+
 ## Supported input modes
 
 | Mode | Typical source | Timestamp behavior | Review anchor |

--- a/docs/release-v0.5.0.md
+++ b/docs/release-v0.5.0.md
@@ -18,6 +18,19 @@ for reviewers to verify.
 - Added false-positive taxonomy and forensic-style case-study documentation for
   evidence interpretation.
 
+## Release readiness checklist
+
+| Requirement | Release-facing evidence | Reviewer check |
+| --- | --- | --- |
+| Changelog names v0.5.0 | [`CHANGELOG.md`](../CHANGELOG.md) | `v0.5.0` exists with explainability, parser observability, and case-study entries |
+| Release note theme is Evidence Explainability Release | This document | Title and highlights frame v0.5 around explainability and verification, not new rule volume |
+| Finding explainability fields are stable JSON contract | [`docs/report-artifacts.md`](./report-artifacts.md) and [`tests/fixtures/report_contracts/syslog_legacy/report.json`](../tests/fixtures/report_contracts/syslog_legacy/report.json) | Finding objects expose `rule_id`, `subject_kind`, `subject`, `grouping_key`, `window_start`, `window_end`, `threshold`, `observed_count`, `evidence_event_ids`, and `verdict_boundary` |
+| Parser contract is release-facing | [`docs/reviewer-path.md`](./reviewer-path.md) and [`docs/parser-contract.md`](./parser-contract.md) | Reviewer path routes v0.5 review through parser behavior, parser warnings, and detection signal boundaries |
+| Mixed corpus and parser coverage artifact are included | [`assets/mixed_auth_corpus.log`](../assets/mixed_auth_corpus.log) and [`assets/mixed_auth_parser_coverage.json`](../assets/mixed_auth_parser_coverage.json) | Reviewer can inspect dirty-input coverage without running the tool first |
+| False-positive taxonomy is included | [`docs/false-positive-taxonomy.md`](./false-positive-taxonomy.md) | Rule-true evidence is separated from compromise, intent, attribution, and authorization claims |
+| Forensic-style case study is included | [`docs/case-study-linux-auth-bruteforce.md`](./case-study-linux-auth-bruteforce.md) | Raw evidence, normalization, findings, warnings, and boundaries are explained as evidence interpretation |
+| Non-claims are explicit | [Non-claims](#non-claims) | Release note states no compromise verdict, no attribution, no blocking recommendation, and no cross-host correlation |
+
 ## Stable JSON contract
 
 `report.json` now identifies the report artifact contract with:

--- a/docs/reviewer-path.md
+++ b/docs/reviewer-path.md
@@ -54,6 +54,10 @@ fields, explain how parser coverage remains visible for unknown lines, and state
 that findings are bounded triage signals with no compromise verdict,
 attribution, blocking recommendation, or cross-host correlation claim.
 
+Use the release note's
+[`Release readiness checklist`](./release-v0.5.0.md#release-readiness-checklist)
+as the compact pass/fail map for the v0.5 scope.
+
 ## 5-minute artifact review
 
 Inspect:


### PR DESCRIPTION
## Summary
- add a v0.5 release readiness checklist that maps each required release item to reviewer-facing evidence
- add a parser-contract anchor back to the v0.5 Evidence Explainability release path
- link the readiness checklist from the reviewer path

## Boundaries
- documentation-only refinement
- no tag or GitHub Release created
- no parser, detector, CLI, or report-generation behavior changes

## Validation
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -C Debug --output-on-failure`
- `git diff --check`
- local Markdown link check for touched docs
- release readiness checklist row check
- privacy/secret scan for touched docs