### PR TITLE
chore(release): set version to 0.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(LogLens VERSION 0.1.0 LANGUAGES CXX)
+project(LogLens VERSION 0.5.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -135,7 +135,7 @@ int main(int argc, char* argv[]) {
         &version_stderr)
                                              .c_str());
     expect(version_exit == 0, "expected --version to succeed");
-    expect(read_file(version_stdout) == "LogLens 0.1.0\n",
+    expect(read_file(version_stdout) == "LogLens 0.5.0\n",
            "expected --version to print project version to stdout");
     expect(read_file(version_stderr).empty(), "expected --version to keep stderr empty");
 


### PR DESCRIPTION
## Summary
- align the CMake project version with the v0.5.0 release
- update the CLI version contract test to expect LogLens 0.5.0

## Validation
- Windows clean Release build and ctest: 5/5 passed
- WSL Ubuntu LF clean checkout, Release build and ctest: 5/5 passed
- schema v2 golden report contract audit: 4/4 cases verified
- mixed auth corpus privacy and infrastructure whitelist scan: passed
- git diff --check: passed