### PR TITLE
docs(readme): update post-v0.5 release posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ or attribution:
 
 ## Project Status
 
-LogLens is an MVP / early release. The repository is stable enough for public review, local experimentation, and extension, but the parser and detection coverage are intentionally narrow.
+**Release posture:** Early reviewer-stable release with a narrow Linux authentication evidence contract. Parser and detection coverage remain intentionally narrow.
 
 Reviewing the project quickly? Start with [`docs/reviewer-path.md`](./docs/reviewer-path.md), [`docs/reviewer-brief.md`](./docs/reviewer-brief.md), and the [`v0.5 Evidence Explainability release note`](./docs/release-v0.5.0.md). The [`quality gates map`](./docs/quality-gates.md) links claims to tests and fixtures. For detection reasoning, follow the [`one-page incident-style case`](./docs/incident-style-case.md), then use the full [`Linux auth brute-force case study`](./docs/case-study-linux-auth-bruteforce.md), [`rule catalog`](./docs/rule-catalog.md), and [`false-positive taxonomy`](./docs/false-positive-taxonomy.md) for depth. For local scale expectations, see the [`performance envelope`](./docs/performance-envelope.md).
 


### PR DESCRIPTION
## Summary
- replace the pre-release MVP wording after publishing v0.5.0
- describe LogLens as an early reviewer-stable release with a narrow Linux authentication evidence contract
- retain the intentionally narrow parser and detection scope without implying production readiness

## Validation
- required release-posture sentence present
- previous MVP / early release wording absent
- git diff --check passed
- added-line privacy and secret scan passed