### PR TITLE
docs(review): focus external review surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Reviewing the project quickly? Start with [`docs/reviewer-path.md`](./docs/revie
 
 For a shorter external review entry point focused on uncertainty handling, read
 [How LogLens Treats Parser Uncertainty as Evidence](./docs/case-study-parser-uncertainty-as-evidence.md).
+Near-term review boundaries are tracked in the [roadmap](./ROADMAP.md).
 
 ## Why This Project Exists
 
@@ -289,5 +290,8 @@ Tue 2026-03-10 08:31:18 UTC example-host sshd[2245]: Connection closed by authen
 
 ## Future Roadmap
 
-- Additional auth patterns and PAM coverage
-- Larger sanitized test corpus
+- Keep parser uncertainty visible through deterministic warning buckets.
+- Add additional auth patterns only with a sanitized sample input, expected
+  event or warning output, and focused tests.
+- Expand the sanitized corpus only when it answers a distinct parser coverage
+  question.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,28 @@
+# Roadmap
+
+LogLens is in a narrow reviewer-stable phase. The near-term focus is to
+stabilize parser evidence, tests, documentation boundaries, and release
+artifacts rather than expand the project surface.
+
+## External Review Surface
+
+Open review issues should stay concrete enough to reproduce from checked-in
+fixtures. A good issue names the exact sample input, the expected event or
+warning output, and the acceptance criteria for a bounded change or review.
+
+The current public review entry is intentionally small: trace one
+`pam_unix_session_closed` line through parser-coverage telemetry and confirm
+that unsupported auth evidence remains visible without becoming detector
+evidence.
+
+## Parked Directions
+
+- Add parser coverage only when a sanitized fixture line and deterministic
+  expected event or warning bucket are known up front.
+- Keep clean-clone reproduction feedback tied to exact failing commands or
+  documentation mismatches.
+- Grow the noisy auth corpus only when a proposed batch answers a new parser
+  uncertainty question not already covered by `assets/mixed_auth_corpus.log`.
+- Keep additional PAM or SSH variants scoped to defensive Linux authentication
+  evidence; no live logs, real identifiers, credentials, or platform-coverage
+  claims.


### PR DESCRIPTION
## Summary
- add a compact roadmap for parked external-review directions
- link the roadmap from README and narrow the future roadmap wording
- keep the public issue list focused on one concrete parser-coverage review task

## Validation
- ctest --test-dir build -C Release --output-on-failure: 5 passed
- git diff --check: passed
- privacy/secret diff scan: passed