### PR TITLE
ci(codeql): synchronize action version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           languages: c-cpp
 
@@ -34,4 +34,4 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Analyze
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0


### PR DESCRIPTION
## Summary
- synchronize CodeQL `init` and `analyze` actions on v4.37.0
- use the peeled v4.37.0 commit SHA for both steps
- replaces the two failing split Dependabot PRs for CodeQL action init/analyze

## Validation
- `git ls-remote https://github.com/github/codeql-action.git 'refs/tags/v4.37.0^{}'`
- `actionlint` across `.github/workflows/*.yml`
- `git diff --check`
- privacy/security string scan on touched workflow

## Notes
The previous split Dependabot PRs failed because CodeQL loaded configuration for one action version while the other step ran a different version.
