### PR TITLE
fix(release): mark main as v0.6 development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(LogLens VERSION 0.5.0 LANGUAGES CXX)
+project(LogLens VERSION 0.6.0 LANGUAGES CXX)
+
+set(
+    LOGLENS_VERSION_SUFFIX
+    "-dev"
+    CACHE STRING
+    "Prerelease suffix appended to the LogLens project version"
+)
+set(LOGLENS_VERSION "${PROJECT_VERSION}${LOGLENS_VERSION_SUFFIX}")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -35,7 +43,7 @@ target_include_directories(loglens_lib
 
 add_executable(loglens src/main.cpp)
 target_link_libraries(loglens PRIVATE loglens_lib)
-target_compile_definitions(loglens PRIVATE LOGLENS_VERSION="${PROJECT_VERSION}")
+target_compile_definitions(loglens PRIVATE LOGLENS_VERSION="${LOGLENS_VERSION}")
 
 include(CTest)
 if(BUILD_TESTING)

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -135,7 +135,7 @@ int main(int argc, char* argv[]) {
         &version_stderr)
                                              .c_str());
     expect(version_exit == 0, "expected --version to succeed");
-    expect(read_file(version_stdout) == "LogLens 0.5.0\n",
+    expect(read_file(version_stdout) == "LogLens 0.6.0-dev\n",
            "expected --version to print project version to stdout");
     expect(read_file(version_stderr).empty(), "expected --version to keep stderr empty");
 


### PR DESCRIPTION
## Summary
- Set CMake's numeric project version to 0.6.0 and add a default `-dev` prerelease suffix.
- Compile the composed `0.6.0-dev` value into the CLI and pin it in the CLI regression test.

## Why
`main` already contains the unreleased v0.6 episode semantics, finding identity, and audit signals, but `loglens --version` still reported the published v0.5.0 release.

## How to validate
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build --config Release`
- `ctest --test-dir build -C Release --output-on-failure`
- `loglens --version` prints `LogLens 0.6.0-dev`
- Repeated with GCC under WSL; 6/6 tests passed on both toolchains.

## Risk / rollout notes
- Design decision: keep CMake's project version numeric while composing the SemVer prerelease suffix separately, so RC and stable builds can use `-rc1` and an empty suffix.
- Main risk: downstream scripts that asserted the stale `0.5.0` CLI output will need to accept the correct development version.
- Compatibility impact: no parser, detector, report, or CLI argument behavior changes; only version reporting changes.
- Rollback path: revert commit `1e28b66` to restore the previous CMake and CLI version.