### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,35 +6,11 @@ All notable user-visible changes should be recorded here.
 
 ### Added
 
-- Added stable JSON finding identity fields: `finding_id` and
-  `episode_index`.
-- Added a separated-burst syslog report-contract fixture where one source IP
-  produces two time-separated brute-force findings.
-- Added detector regression coverage for stable episode identity under unsorted
-  input order and inclusive window-boundary behavior.
-- Added parser regression coverage for malformed source-IP token
-  classification.
-- Added deterministic parser property tests for registry-order independence,
-  generated malformed tokens, failure taxonomy stability, and arbitrary-byte
-  result invariants.
-- Added an optional Clang libFuzzer parser target with a sanitized seed corpus
-  and bounded Ubuntu CI smoke campaign.
-- Added a dedicated util-linux `login` handler for selected failed-login,
-  retry-exhaustion, session-failure, local-login, and root-login messages.
-- Expanded the sanitized mixed auth corpus from 150 to 160 lines with ten
-  fixture-backed `login` records and updated parser coverage telemetry.
+- None yet.
 
 ### Changed
 
-- Refactored parser internals into timestamp, source-envelope, program-dispatch,
-  program-handler, and failure-classifier modules behind the unchanged
-  `AuthLogParser` interface.
-- Detector rules now emit separate findings for time-separated detection
-  episodes within the same rule subject instead of collapsing each subject to a
-  single best window.
-- Bumped the JSON report artifact contract from `loglens.report.v2` /
-  `schema_version` 2 to `loglens.report.v3` / `schema_version` 3 for finding
-  identity fields.
+- None yet.
 
 ### Fixed
 
@@ -42,10 +18,35 @@ All notable user-visible changes should be recorded here.
 
 ### Docs
 
-- Documented detection episode semantics in the rule catalog and report artifact
-  contract notes.
-- Added the v0.6 Detection Episode Semantics release note and schema v2 to v3
-  migration guidance.
+- None yet.
+
+## v0.6.0
+
+### Added
+
+- Added multiple time-separated detector episodes for one rule subject.
+- Added stable finding identity fields: `finding_id` and `episode_index`.
+- Added a parser handler registry that keeps program-specific parsing modular.
+- Added deterministic parser property coverage and an optional libFuzzer smoke
+  target with a sanitized seed corpus.
+- Added a dedicated util-linux `login` handler for selected login failure and
+  session messages.
+- Added audit-only privilege authentication signals for sudo and su failures;
+  these remain visible without counting as detector evidence by default.
+
+### Changed
+
+- Bumped the JSON report artifact contract from `loglens.report.v2` /
+  `schema_version` 2 to `loglens.report.v3` / `schema_version` 3, including
+  `finding_id` and `episode_index`.
+
+### Fixed
+
+- None yet.
+
+### Docs
+
+- Added the v0.6 release note and schema v2 to v3 migration guidance.
 
 ## v0.5.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(LogLens VERSION 0.6.0 LANGUAGES CXX)
 
 set(
     LOGLENS_VERSION_SUFFIX
-    "-dev"
+    ""
     CACHE STRING
     "Prerelease suffix appended to the LogLens project version"
 )

--- a/docs/release-v0.6.0.md
+++ b/docs/release-v0.6.0.md
@@ -1,10 +1,9 @@
-# LogLens v0.6.0 - Detection Episode Semantics
+# LogLens v0.6.0 - Detection Episodes, Parser Coverage, and Audit Signals
 
-Theme: Detection Episode Semantics.
+Theme: Detection Episodes, Parser Coverage, and Audit Signals.
 
-This release note describes the v0.6 report and detector contract. It does not
-add new detection rules. It makes repeated time-separated findings for the same
-rule subject explicit and reviewable.
+This release note describes the fixed v0.6 report, parser, coverage, and audit
+signal contract. It does not add new detection rules.
 
 ## What Changed
 
@@ -15,6 +14,13 @@ rule subject explicit and reviewable.
 - JSON findings include stable finding identity fields:
   - `finding_id`
   - `episode_index`
+- Parser internals are organized behind a program handler registry.
+- Deterministic parser property coverage and an optional libFuzzer smoke target
+  cover malformed and arbitrary-byte input invariants.
+- A dedicated util-linux `login` handler normalizes selected login failure and
+  session messages while preserving unsupported variants as warnings.
+- Privilege authentication failures from `sudo` and `su` are exposed as
+  audit-only signals and do not count as detector evidence by default.
 - The separated-burst contract fixture demonstrates one source IP producing two
   distinct brute-force findings in one report.
 
@@ -96,6 +102,9 @@ v0.6 is covered by:
 - detector tests for stable episode identity under unsorted input order
 - detector tests for inclusive rule-window boundaries
 - parser tests for malformed source-IP token classification
+- parser handler registry and util-linux `login` coverage
+- deterministic parser property tests and bounded fuzz smoke coverage
+- audit-only privilege authentication signal behavior
 - report tests for `finding_id`, `episode_index`, and schema v3 output
 - golden report-contract fixtures for Markdown, JSON, and optional CSV reports
 

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -135,7 +135,7 @@ int main(int argc, char* argv[]) {
         &version_stderr)
                                              .c_str());
     expect(version_exit == 0, "expected --version to succeed");
-    expect(read_file(version_stdout) == "LogLens 0.6.0-dev\n",
+    expect(read_file(version_stdout) == "LogLens 0.6.0\n",
            "expected --version to print project version to stdout");
     expect(read_file(version_stderr).empty(), "expected --version to keep stderr empty");
 


### PR DESCRIPTION
## Summary
- Cut the stable `v0.6.0` CLI version from the existing v0.6 development line.
- Freeze the fixed v0.6 release contents: multiple time-separated episodes, `finding_id` / `episode_index`, report schema v3, parser handler registry, property/fuzz coverage, util-linux `login`, and audit-only privilege auth signals.
- Move the release entries out of `Unreleased` and align the v0.6 release note with the shipped contract.

## Validation
- Windows/MSVC Release build from a fresh temporary build directory.
- `ctest --test-dir ... -C Release --output-on-failure`: 6/6 passed.
- Independent JSON consumer: `CONSUMER_COMPATIBILITY_OK schema=loglens.report.v3 schema_version=3 findings=2 episodes=1,2`.
- `actionlint` passed for all workflows.
- `git diff --check` and JSON/privacy path scans passed.

## Release protocol
- Design decision: keep the numeric CMake project version at `0.6.0` and use an empty suffix for the stable release; the existing suffix mechanism remains available for prerelease builds.
- Main risk: downstream report consumers must migrate from `loglens.report.v2` / `schema_version: 2` to v3 and use stable finding identity fields.
- Compatibility impact: report JSON changes to schema v3; CLI parsing and the optional CSV contract remain unchanged.
- Rollback path: revert `6f99de5` and remove the release tag/release if the release verification gates fail.
- Issues #100–#102 are deliberately excluded from this release.