### PR TITLE
ci: synchronize CodeQL init/analyze to v4.37.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           languages: c-cpp
 
@@ -38,4 +38,4 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Analyze
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6


### PR DESCRIPTION
## Summary
- Synchronize `github/codeql-action/init` and `github/codeql-action/analyze` to the same pinned v4.37.6 commit SHA:
  `5595ccaf912efad79be6eef63a5619ff05969be3`.
- This maintainer PR supersedes split Dependabot PRs #105 and #106; they should not be merged independently.

## Validation
- `actionlint` passed for all repository workflows.
- Local pin check confirmed exactly two CodeQL action pins and one shared SHA.
- `git diff --check` passed.
- Required remote validation: CI and CodeQL checks on this maintainer PR.

## Review protocol
- Design decision: keep `init` and `analyze` on one immutable commit so the CodeQL workflow cannot run a mixed action version.
- Main risk: CodeQL action behavior changes with the v4.37.6 update; the pinned SHA makes the change reproducible and reviewable.
- Compatibility impact: no application/runtime changes; only GitHub Actions security-analysis tooling changes.
- Rollback path: revert `459a244` to restore the previous v4.37.0 pin.
- After this PR is merged and verified, close #105 and #106 without merging them.